### PR TITLE
Go to production android

### DIFF
--- a/docs/integrate-android-sdk/check-user-state.md
+++ b/docs/integrate-android-sdk/check-user-state.md
@@ -4,7 +4,7 @@ description: Detailed information on using the CONNECT Android SDK for integrati
 collection: integrate-android-sdk
 order: 5
 lunr: true
-nav_sort: 4
+nav_sort: 5
 nav_groups:
   - primary
 tags:

--- a/docs/integrate-android-sdk/customise-the-user-experience.md
+++ b/docs/integrate-android-sdk/customise-the-user-experience.md
@@ -4,7 +4,7 @@ description: Detailed information on using the CONNECT Android SDK for integrati
 collection: integrate-android-sdk
 order: 6
 lunr: true
-nav_sort: 5
+nav_sort: 6
 nav_groups:
   - primary
 tags:

--- a/docs/integrate-android-sdk/go-to-production.md
+++ b/docs/integrate-android-sdk/go-to-production.md
@@ -23,3 +23,5 @@ To target the production enviroment initialize the SDK with the `useStagingEnvir
 ```java
 ConnectSdk.sdkInitialize(getApplicationContext(), false);
 ```
+
+Reference & explanation: <a target="_blank" href="http://docs.telenordigital.com/connect/environments.html">Environments</a><i class="material-icons md-18">open_in_new</i>

--- a/docs/integrate-android-sdk/go-to-production.md
+++ b/docs/integrate-android-sdk/go-to-production.md
@@ -18,7 +18,7 @@ tags:
 ---
 
 ## Target the production environment
-To target the production enviroment initialize the SDK with the `useStagingEnviroment` parameter set to `false`:
+To target the production environment initialize the SDK with the `useStagingEnvironment` parameter set to `false`:
 
 ```java
 ConnectSdk.sdkInitialize(getApplicationContext(), false);

--- a/docs/integrate-android-sdk/go-to-production.md
+++ b/docs/integrate-android-sdk/go-to-production.md
@@ -1,0 +1,25 @@
+---
+title: Go to production
+description: How to set the CONNECT Android SDK to target the production environment
+collection: integrate-android-sdk
+order: 7
+lunr: true
+nav_sort: 7
+nav_groups:
+  - primary
+tags:
+  - sdk
+  - android
+  - guide
+  - setup
+  - production
+  - staging
+  - how to
+---
+
+## Target the production environment
+To target the production enviroment initialize the SDK with the `useStagingEnviroment` parameter set to `false`:
+
+```java
+ConnectSdk.sdkInitialize(getApplicationContext(), false);
+```

--- a/docs/integrate-android-sdk/setup.md
+++ b/docs/integrate-android-sdk/setup.md
@@ -36,20 +36,6 @@ allprojects {
 
 Before using the SDK some entries have to be added to `AndroidManifest.xml`. See instructions below. The example app also contains [a full example of a valid `AndroidManifest.xml`](https://github.com/telenordigital/connect-android-sdk/blob/master/connect-id-example/src/main/AndroidManifest.xml).
 
-## Set Staging or Production Environment
-
-CONNECT ID has two [environments](http://docs.telenordigital.com/connect/environments.html)
-that can be used, `staging` and `production`. The environment can be selected using the
-`com.telenor.connect.USE_STAGING` meta-data property in your AndroidManifest.xml
-
-```xml
-<meta-data
-        android:name="com.telenor.connect.USE_STAGING"
-        android:value="true" />
-```
-
-Set this to `false` if you want to use the production environment.
-
 ## Add client ID and redirect URI
 
 The CONNECT ID integration requires a client ID and a redirect URI to work. You should receive these when registering your application. See [Required registration details](../get-started/client-registration-details.md).


### PR DESCRIPTION
* Addresses change in the Android SDK on how you set the environment: https://github.com/telenordigital/connect-android-sdk/pull/124
* Removes explanatory information in favour of keeping the information a how-to guide, and links to reference and explanation.
* Corrects some `nav_sort` params.